### PR TITLE
Spring Actuator security services layer with /manage context path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .project
 .settings
 target/
+git.properties

--- a/spring-boot-mvc-rest/src/test/resources/application.properties
+++ b/spring-boot-mvc-rest/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+endpoints.autoconfig.enabled=true

--- a/spring-boot-mvc-web/pom.xml
+++ b/spring-boot-mvc-web/pom.xml
@@ -85,12 +85,144 @@
 			<artifactId>hsqldb</artifactId>
 		</dependency>
 
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-remote-shell</artifactId>
+		</dependency>
+
 	</dependencies>
 	<build>
 		<plugins>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>pl.project13.maven</groupId>
+				<artifactId>git-commit-id-plugin</artifactId>
+				<executions>
+					<execution>
+						<goals>
+							<goal>revision</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<!-- that's the default value, you don't have to set it -->
+					<prefix>git</prefix>
+
+					<!-- that's the default value -->
+					<dateFormat>dd.MM.yyyy '@' HH:mm:ss z</dateFormat>
+
+					<!-- false is default here, it prints some more information during the 
+						build -->
+					<verbose>false</verbose>
+
+					<!-- @since 2.1.10 -->
+					<!-- false is default here, if set to true it uses native `git` excutable 
+						for extracting all data. This usualy has better performance than the default 
+						(jgit) implemenation, but requires you to have git available as executable 
+						for the build as well as *might break unexpectedly* when you upgrade your 
+						system-wide git installation. As rule of thumb - stay on `jgit` (keep this 
+						`false`) until you notice performance problems. -->
+					<useNativeGit>false</useNativeGit>
+
+					<!-- If you'd like to tell the plugin where your .git directory is, 
+						use this setting, otherwise we'll perform a search trying to figure out the 
+						right directory. It's better to add it explicite IMHO. -->
+					<dotGitDirectory>${project.basedir}/.git</dotGitDirectory>
+
+					<!-- ALTERNATE SETUP - GENERATE FILE -->
+					<!-- If you want to keep git information, even in your WAR file etc, 
+						use this mode, which will generate a properties file (with filled out values) 
+						which you can then normally read using new Properties().load(/**/) -->
+
+					<!-- this is true by default; You may want to set this to false, if 
+						the plugin should run inside a <packaging>pom</packaging> project. Most projects 
+						won't need to override this property. For an use-case for this kind of behaviour 
+						see: https://github.com/ktoso/maven-git-commit-id-plugin/issues/21 -->
+					<skipPoms>true</skipPoms>
+
+					<!-- this is false by default, forces the plugin to generate the git.properties 
+						file -->
+					<generateGitPropertiesFile>true</generateGitPropertiesFile>
+
+					<!-- The path for the to be generated properties file, it's relative 
+						to ${project.basedir} -->
+					<generateGitPropertiesFilename>src/main/resources/git.properties</generateGitPropertiesFilename>
+
+					<!-- true by default, controls whether the plugin will fail when no 
+						.git directory is found, when set to false the plugin will just skip execution -->
+					<!-- @since 2.0.4 -->
+					<failOnNoGitDirectory>true</failOnNoGitDirectory>
+
+					<!-- @since v2.0.4 -->
+					<!-- Controls the length of the abbreviated git commit it (git.commit.id.abbrev) 
+						Defaults to `7`. `0` carries the special meaning. Maximum value is `40`, 
+						because of max SHA-1 length. -->
+					<abbrevLength>30</abbrevLength>
+
+					<!-- @since 2.1.8 -->
+					<!-- skip the plugin execution completely. This is useful for e.g. profile 
+						activated plugin invocations or to use properties to enable / disable pom 
+						features. Default value is 'false'. -->
+					<skip>false</skip>
+
+					<!-- @since 2.1.12 -->
+					<!-- Use with caution! In a multi-module build, only run once. This 
+						means that the plugins effects will only execute once, for the parent project. 
+						This probably won't "do the right thing" if your project has more than one 
+						git repository. Important: If you're using `generateGitPropertiesFile`, setting 
+						`runOnlyOnce` will make the plugin only generate the file in the directory 
+						where you started your build (!). The `git.*` maven properties are available 
+						in all modules. Default value is `false`. -->
+					<runOnlyOnce>false</runOnlyOnce>
+
+					<!-- @since 2.1.9 -->
+					<!-- Can be used to exclude certain properties from being emited into 
+						the resulting file. May be useful when you want to hide {@code git.remote.origin.url} 
+						(maybe because it contains your repo password?), or the email of the committer 
+						etc. Each value may be globbing, that is, you can write {@code git.commit.user.*} 
+						to exclude both, the {@code name}, as well as {@code email} properties from 
+						being emitted into the resulting files. Please note that the strings here 
+						are Java regexes ({@code .*} is globbing, not plain {@code *}). -->
+					<excludeProperties>
+						<!-- <excludeProperty>git.user.*</excludeProperty> -->
+					</excludeProperties>
+
+
+					<!-- @since 2.1.0 -->
+					<!-- read up about git-describe on the in man, or it's homepage - it's 
+						a really powerful versioning helper and the recommended way to use git-commit-id-plugin. 
+						The configuration bellow is optional, by default describe will run "just 
+						like git-describe on the command line", even though it's a JGit reimplementation. -->
+					<gitDescribe>
+
+						<!-- don't generate the describe property -->
+						<skip>false</skip>
+
+						<!-- if no tag was found "near" this commit, just print the commit's 
+							id instead, helpful when you always expect this field to be not-empty -->
+						<always>false</always>
+						<!-- how many chars should be displayed as the commit object id? 7 
+							is git's default, 0 has a special meaning (see end of this README.md), and 
+							40 is the maximum value here -->
+						<abbrev>7</abbrev>
+
+						<!-- when the build is triggered while the repo is in "dirty state", 
+							append this suffix -->
+						<dirty>-dirty</dirty>
+
+						<!-- Only consider tags matching the given pattern. This can be used 
+							to avoid leaking private tags from the repository. -->
+						<match>*</match>
+
+						<!-- always print using the "tag-commits_from_tag-g_commit_id-maybe_dirty" 
+							format, even if "on" a tag. The distance will always be 0 if you're "on" 
+							the tag. -->
+						<forceLongFormat>false</forceLongFormat>
+					</gitDescribe>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/spring-boot-mvc-web/src/main/java/com/mylab/Application.java
+++ b/spring-boot-mvc-web/src/main/java/com/mylab/Application.java
@@ -95,9 +95,10 @@ public class Application extends WebMvcConfigurerAdapter {
 	        ErrorPage error401Page = new ErrorPage(HttpStatus.UNAUTHORIZED, "/401.html");
 	        ErrorPage error403Page = new ErrorPage(HttpStatus.FORBIDDEN, "/403.html");
 	        ErrorPage error404Page = new ErrorPage(HttpStatus.NOT_FOUND, "/404.html");
+	        ErrorPage error405Page = new ErrorPage(HttpStatus.METHOD_NOT_ALLOWED, "/405.html");
 	        ErrorPage error500Page = new ErrorPage(HttpStatus.INTERNAL_SERVER_ERROR, "/500.html");
 	 
-	        container.addErrorPages(error401Page, error403Page, error404Page, error500Page,error400Page);
+	        container.addErrorPages(error401Page, error403Page, error404Page, error405Page, error500Page,error400Page);
 	   });
 	}
 } 

--- a/spring-boot-mvc-web/src/main/java/com/mylab/ManagementSecurityConfig.java
+++ b/spring-boot-mvc-web/src/main/java/com/mylab/ManagementSecurityConfig.java
@@ -1,0 +1,22 @@
+package com.mylab;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+
+@Order(0)
+@Configuration
+public class ManagementSecurityConfig extends WebSecurityConfigurerAdapter {
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+         http
+            .requestMatchers()
+                .requestMatchers(request -> "/manage".equals(request.getContextPath()))
+                .and()
+            .authorizeRequests()
+                .anyRequest().hasRole("ADMIN")
+                .and()
+            .httpBasic();
+    }
+}

--- a/spring-boot-mvc-web/src/main/java/com/mylab/WebSecurityConfig.java
+++ b/spring-boot-mvc-web/src/main/java/com/mylab/WebSecurityConfig.java
@@ -3,6 +3,7 @@ package com.mylab;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -50,6 +51,9 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
         .sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED);
 //        .invalidSessionUrl("/?invalid");
 	}
+	
+	
+	
 
 	/**
 	 * Configure global security with Bccyptenoncder and custom userDetailService with Spring Security

--- a/spring-boot-mvc-web/src/main/java/com/mylab/WebSecurityConfig.java
+++ b/spring-boot-mvc-web/src/main/java/com/mylab/WebSecurityConfig.java
@@ -38,18 +38,21 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 	@Override
 	protected void configure(HttpSecurity http) throws Exception {
 
-		http.authorizeRequests().antMatchers("/pizzas","/info","/addPizza").hasAnyRole("USER","ADMIN").and()
-		.authorizeRequests().antMatchers("/users","/addUser").hasRole("ADMIN").and()
-		.authorizeRequests().antMatchers("/static/**","/logout","/login").permitAll();
-		
-	    http.formLogin().loginPage("/login").failureUrl("/login?error").permitAll();
-		
-		http.logout().logoutSuccessUrl("/?logout").deleteCookies("remember-me").permitAll();
-		
-		
-		http.sessionManagement().maximumSessions(1).expiredUrl("/?expired").maxSessionsPreventsLogin(true).and()
-        .sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED);
-//        .invalidSessionUrl("/?invalid");
+		 http
+		    .authorizeRequests()
+		        .antMatchers("/pizzas","/info","/addPizza").hasAnyRole("USER","ADMIN")
+		        .antMatchers("/users","/addUser").hasRole("ADMIN")
+		        .antMatchers("/static/**","/logout","/login").permitAll()
+		        .and()
+		    .formLogin()
+		        .loginPage("/login")
+		        .failureUrl("/login?error")
+		        .permitAll()
+		        .and()
+		    .logout()
+		        .logoutSuccessUrl("/?logout")
+		        .deleteCookies("remember-me")
+		        .permitAll();
 	}
 	
 	

--- a/spring-boot-mvc-web/src/main/resources/application.yml
+++ b/spring-boot-mvc-web/src/main/resources/application.yml
@@ -5,6 +5,10 @@
 management:
     port: 9091
     address: 127.0.0.1
+    context-path: /manage
+    security: 
+            enabled: true
+            role: ADMIN
 http:
     mappers: 
        jsonPrettyPrint: true

--- a/spring-boot-mvc-web/src/main/resources/static/405.html
+++ b/spring-boot-mvc-web/src/main/resources/static/405.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Page Not Found</title>
+    <style>
+        ::-moz-selection {
+            background: #b3d4fc;
+            text-shadow: none;
+        }
+
+        ::selection {
+            background: #b3d4fc;
+            text-shadow: none;
+        }
+
+        html {
+            padding: 30px 10px;
+            font-size: 20px;
+            line-height: 1.4;
+            color: #737373;
+            background: #f0f0f0;
+            font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+            -webkit-text-size-adjust: 100%;
+            -ms-text-size-adjust: 100%;
+        }
+
+        body {
+            max-width: 550px;
+            _width: 550px;
+            padding: 30px 20px 50px;
+            border: 1px solid #b3b3b3;
+            border-radius: 4px;
+            margin: 0 auto;
+            box-shadow: 0 1px 10px #a7a7a7, inset 0 1px 0 #fff;
+            background: #fcfcfc;
+        }
+
+        h1 {
+            margin: 0 10px;
+            font-size: 50px;
+            text-align: center;
+        }
+
+        h1 span {
+            color: #bbb;
+        }
+
+        h3 {
+            margin: 1.5em 0 0.5em;
+        }
+
+        p {
+            margin: 1em 0;
+        }
+
+        ul {
+            padding: 0 0 0 40px;
+            margin: 1em 0;
+        }
+
+        .container {
+            max-width: 500px;
+            _width: 500px;
+            margin: 0 auto;
+        }
+
+    </style>
+</head>
+<body>
+<div class="container">
+    <h1>Method do not allowed for your user <span>:(</span></h1>
+   
+</div>
+</body>
+</html>


### PR DESCRIPTION
Trying to secure spring actuator services /manage context path when calling for example:

http://localhost:9091/manage/info


But when i do a get http request spring security redirect to login page to manage Spring boot activator app,( http://localhost:9091/manage/login), obviously this page does not exist because it is at Spring boot app with "pizza" context path.

![screen shot 2015-03-10 at 13 35 55](https://cloud.githubusercontent.com/assets/7360956/6574966/7cff4fc0-c72a-11e4-9df0-e943f5fbb682.png)








