### PR TITLE
Update Spring IO Platform to 1.1.2 version

### DIFF
--- a/mylab-parent-pom/pom.xml
+++ b/mylab-parent-pom/pom.xml
@@ -16,7 +16,7 @@
 		<javax.mail.version>1.4</javax.mail.version>
 		<jaxb.api.version>2.2.11</jaxb.api.version>
 		<openpojo.version>0.5.0</openpojo.version>
-		<spring.io.version>1.1.1.RELEASE</spring.io.version>
+		<spring.io.version>1.1.2.RELEASE</spring.io.version>
 		<downloadSources>true</downloadSources>
 		<downloadJavadocs>true</downloadJavadocs>
 	</properties>


### PR DESCRIPTION
New version of Spring Platform has been released. https://spring.io/blog/2015/04/01/spring-io-platform-1-1-2-released